### PR TITLE
Add voice capture and speech synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Super H est un plugin d'intégration pour l'interface web de ChatGPT. Il s'inspi
 - 📝 **Notes par conversation** : stockage local et synchronisation future.
 - 🌉 **Galerie d'images** : historiser et rechercher les images générées par ChatGPT.
 - 🔄 **Synchronisation** : partage des paramètres et de l'historique entre appareils.
-- 🔊 **Voice GPT** : conversion texte/parole pour discuter avec ChatGPT.
+- 🔊 **Voice GPT** : capture micro, transcription Whisper et synthèse vocale.
 - 🖱️ **Menu contextuel** : accès rapide aux invites favorites sur tout le web.
 - 🛠️ **Utilitaires** : profils d'instructions, résumés automatiques, sélecteur de modèle, etc.
 
@@ -14,6 +14,7 @@ Super H est un plugin d'intégration pour l'interface web de ChatGPT. Il s'inspi
 
 ```
 manifest.json        # Manifest MV3 pour l'extension
+src/audio.js         # Module de capture audio et transcription
 src/content.js       # Script de contenu injecté sur chat.openai.com
 package.json         # Dépendances (markdown-it, postcss)
 ```
@@ -29,6 +30,13 @@ package.json         # Dépendances (markdown-it, postcss)
    npm test
    ```
 3. Charger le dossier comme extension non empaquetée dans votre navigateur.
+
+## Flux vocal
+
+1. Cliquez sur **Start** pour démarrer l'enregistrement via le micro.
+2. À l'arrêt (**Stop**), le flux audio est envoyé à l'API Whisper pour transcription.
+3. La transcription s'affiche dans le bandeau Super H et peut être utilisée comme entrée.
+4. À chaque réponse de ChatGPT, une synthèse vocale est générée via l'API Web Speech.
 
 ## Ressources intégrées
 - [Superpower ChatGPT](https://github.com/saeedezzati/superpower-chatgpt)

--- a/manifest.json
+++ b/manifest.json
@@ -6,9 +6,9 @@
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/*"],
-      "js": ["src/content.js"],
+      "js": ["src/audio.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ],
-  "permissions": []
+  "permissions": ["microphone"]
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,54 @@
+// Microphone capture and Whisper transcription module
+(function() {
+  let mediaRecorder;
+  let audioChunks = [];
+  let transcriptionCallback = null;
+
+  async function startRecording(onTranscription) {
+    transcriptionCallback = onTranscription;
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioChunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+
+    mediaRecorder.addEventListener('dataavailable', event => {
+      audioChunks.push(event.data);
+    });
+
+    mediaRecorder.addEventListener('stop', async () => {
+      const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
+      try {
+        const text = await transcribeAudio(audioBlob);
+        if (transcriptionCallback) transcriptionCallback(text);
+      } catch (err) {
+        console.error('Transcription error', err);
+      }
+    });
+
+    mediaRecorder.start();
+  }
+
+  function stopRecording() {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+  }
+
+  async function transcribeAudio(blob) {
+    const formData = new FormData();
+    formData.append('file', blob, 'audio.webm');
+    formData.append('model', 'whisper-1');
+    // Replace with your Whisper or internal transcription endpoint
+    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${window.superH?.openAiKey || ''}`
+      },
+      body: formData
+    });
+    const data = await response.json();
+    return data.text || '';
+  }
+
+  window.superH = window.superH || {};
+  window.superH.audio = { startRecording, stopRecording };
+})();

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,4 @@
-// Super H content script
+// Super H content script with voice features
 (function() {
   const container = document.createElement('div');
   container.id = 'super-h-banner';
@@ -11,6 +11,49 @@
   container.style.padding = '4px 8px';
   container.style.borderRadius = '4px';
   container.style.fontSize = '12px';
-  container.textContent = 'Super H active';
+  container.textContent = 'Super H voice ready';
+
+  const startBtn = document.createElement('button');
+  startBtn.textContent = 'Start';
+  startBtn.style.marginLeft = '8px';
+  const stopBtn = document.createElement('button');
+  stopBtn.textContent = 'Stop';
+  stopBtn.style.marginLeft = '4px';
+  const transcriptionDiv = document.createElement('div');
+  transcriptionDiv.style.marginTop = '4px';
+  transcriptionDiv.style.maxWidth = '200px';
+  transcriptionDiv.style.wordWrap = 'break-word';
+
+  container.appendChild(startBtn);
+  container.appendChild(stopBtn);
+  container.appendChild(transcriptionDiv);
   document.body.appendChild(container);
+
+  startBtn.addEventListener('click', () => {
+    window.superH.audio.startRecording(text => {
+      transcriptionDiv.textContent = text;
+    });
+  });
+
+  stopBtn.addEventListener('click', () => {
+    window.superH.audio.stopRecording();
+  });
+
+  function speak(text) {
+    const utterance = new SpeechSynthesisUtterance(text);
+    speechSynthesis.speak(utterance);
+  }
+
+  const observer = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE && node.matches('div[data-message-author-role="assistant"]')) {
+          const text = node.innerText;
+          speak(text);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
 })();


### PR DESCRIPTION
## Summary
- add `audio.js` to record microphone and send audio to Whisper for transcription
- expose start/stop recording and speak ChatGPT replies in `content.js`
- request microphone permission and document voice flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896325a4924832f821c7e053a6b8e72